### PR TITLE
Manjaro installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ command:
     make
     ./blackvoxel
 
+### Manjaro
+
+    sudo pacman -S base-devel glew1.10 sdl
+    tar xf blackvoxel_source*
+    make
+    ./blackvoxel
+
 ### Other Linux distributions
 
 Blackvoxel can be compiled in debian and ubuntu derived (like Mint) in


### PR DESCRIPTION
`base-devel` is Manjaro-specific, and I don't know what build tools are guaranteed in Arch installations.