### PR TITLE
Improve Makefiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,11 +94,11 @@ installable: BV_DATA_LOCATION_DIR=$(BV_DATA_INSTALL_DIR)
 installable: all
 
 squirrel: 
-	cd src/sc_Squirrel3 ; make sq$(CPU_BITS)
+	cd src/sc_Squirrel3 ; $(MAKE) sq$(CPU_BITS)
 
 clean:
 	@rm -rf obj
-	@cd src/sc_Squirrel3 ; make clean
+	@cd src/sc_Squirrel3 ; $(MAKE) clean
 	@rm -f $(PROGNAME)
 
 mrproper: clean

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,9 @@ override BV_DATA_INSTALL_DIR:="$(DESTDIR)$(BV_DATA_INSTALL_DIR)"
 endif
 
 # Base options
-CC=g++
-LD=g++
+CXX?=g++
 PROGNAME=blackvoxel
-CFLAGS=-I "src/sc_Squirrel3/include"  -DCOMPILEOPTION_DEMO=0 -DDEVELOPPEMENT_ON=0 -DCOMPILEOPTION_SPECIAL=0 -DCOMPILEOPTION_DATAFILESPATH="\"$(BV_DATA_LOCATION_DIR)\""
+CXXFLAGS+=-I "src/sc_Squirrel3/include"  -DCOMPILEOPTION_DEMO=0 -DDEVELOPPEMENT_ON=0 -DCOMPILEOPTION_SPECIAL=0 -DCOMPILEOPTION_DATAFILESPATH="\"$(BV_DATA_LOCATION_DIR)\""
 SRC= $(wildcard src/*.cpp) $(wildcard src/z/*.cpp)
 OBJ= $(SRC:src/%.cpp=obj/%.o)
 
@@ -56,8 +55,8 @@ OBJ= $(SRC:src/%.cpp=obj/%.o)
 
 ifeq ($(OS),Windows_NT)
   CPU_BITS=32
-  CFLAGS+= -O3 -c -fmessage-length=0 -march=i686
-  LDFLAGS= -s -Xlinker --large-address-aware -mwindows -L"src/sc_Squirrel3/lib" -lmingw32 -lSDLmain -lSDL -llibglew32 -lglu32 -lopengl32 -llibglut -lsquirrel -lsqstdlib
+  CXXFLAGS+= -O3 -c -fmessage-length=0 -march=i686
+  LDFLAGS+= -s -Xlinker --large-address-aware -mwindows -L"src/sc_Squirrel3/lib" -lmingw32 -lSDLmain -lSDL -llibglew32 -lglu32 -lopengl32 -llibglut -lsquirrel -lsqstdlib
 else
   # Unix like operating systems
   CPU_BITS= $(shell getconf LONG_BIT)
@@ -65,31 +64,31 @@ else
   KERNELNAME =$(shell uname -s)
 
   ifeq ($(KERNELNAME),Linux)
-    CFLAGS+= -O3 -c -fmessage-length=0
-    LDFLAGS=-s -zrelro -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
+    CXXFLAGS+= -O3 -c -fmessage-length=0
+    LDFLAGS+=-s -zrelro -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
   else ifeq ($(KERNELNAME), FreeBSD)
     # To be done...
-    CFLAGS+= -O3 -c -fmessage-length=0
-    LDFLAGS=-s -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
+    CXXFLAGS+= -O3 -c -fmessage-length=0
+    LDFLAGS+=-s -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
   else ifeq ($(KERNELNAME), Darwin)
-    CFLAGS+= -O3 -c -fmessage-length=0
-    LDFLAGS=-s -L"src/sc_Squirrel3/lib" -L"/usr/local/Cellar/glew" -L"/usr/local/Cellar/sdl" -I"/usr/local/Cellar/glew" -I"/usr/local/Cellar/sdl" -framework Cocoa -framework OpenGL -lSDLmain -lSDL -lGLEW -lsquirrel -lsqstdlib
+    CXXFLAGS+= -O3 -c -fmessage-length=0
+    LDFLAGS+=-s -L"src/sc_Squirrel3/lib" -L"/usr/local/Cellar/glew" -L"/usr/local/Cellar/sdl" -I"/usr/local/Cellar/glew" -I"/usr/local/Cellar/sdl" -framework Cocoa -framework OpenGL -lSDLmain -lSDL -lGLEW -lsquirrel -lsqstdlib
   else
     # Unknow kernel... trying default flags
-    CFLAGS+= -O3 -c -fmessage-length=0
-    LDFLAGS=-s -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
+    CXXFLAGS+= -O3 -c -fmessage-length=0
+    LDFLAGS+=-s -L"src/sc_Squirrel3/lib" -lGLU -lSDL -lGLEW -lGL -lsquirrel -lsqstdlib
   endif
 endif
 
 
 obj/%.o: src/%.cpp
 	@mkdir -p obj/z
-	$(CC) -o $@ -c $< $(CFLAGS) 
-	
+	$(CXX) -o $@ -c $< $(CXXFLAGS) 
+
 all: $(PROGNAME)
 
 $(PROGNAME): $(OBJ) squirrel
-	$(LD) -o $(PROGNAME) $(OBJ) $(LDFLAGS)
+	$(CXX) -o $(PROGNAME) $(OBJ) $(LDFLAGS)
 
 installable: BV_DATA_LOCATION_DIR=$(BV_DATA_INSTALL_DIR)
 installable: all

--- a/src/sc_Squirrel3/Makefile
+++ b/src/sc_Squirrel3/Makefile
@@ -1,6 +1,5 @@
 
 SQUIRREL=.
-MAKE=make
 
 sq32:
 	cd squirrel; $(MAKE) 

--- a/src/sc_Squirrel3/sq/Makefile
+++ b/src/sc_Squirrel3/sq/Makefile
@@ -12,16 +12,16 @@ SRCS= sq.c
 	
 	
 sq32:
-	g++ -O2 -s -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	$(CXX) -O2 -s -fno-exceptions -fno-rtti -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 
 sqprof:
-	g++ -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	$(CXX) -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 	
 sq64:
-	g++ -O2 -s -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	$(CXX) -O2 -s -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 	
 sq64d:
-	g++ -O0 -g3 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
+	$(CXX) -O0 -g3 -m64 -fno-exceptions -fno-rtti -D_SQ64 -o $(OUT) $(SRCS) $(INCZ) $(LIBZ) $(LIB)
 	
 .PHONY: clean mrproper
 

--- a/src/sc_Squirrel3/sqstdlib/Makefile
+++ b/src/sc_Squirrel3/sqstdlib/Makefile
@@ -26,23 +26,23 @@ SRCS= \
 	
 	
 sq32:
-	gcc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 
 sqprof:
-	gcc -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 	
 sq64:
-	gcc -O2 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 	
 sq64d:
-	gcc -O0 -g3 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
-	ar rc $(OUT) *.o
+	$(CC) -O0 -g3 -m64 -fno-exceptions -D_SQ64 -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ)
+	$(AR) rc $(OUT) *.o
 
 .PHONY: clean mrproper
 	

--- a/src/sc_Squirrel3/squirrel/Makefile
+++ b/src/sc_Squirrel3/squirrel/Makefile
@@ -37,23 +37,23 @@ SRCS= \
 	
 	
 sq32:
-	gcc -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 
 sqprof:
-	gcc -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -pg -fno-exceptions -fno-rtti -pie -gstabs -g3 -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 
 sq64:
-	gcc -O2 -m64 -D_SQ64 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
-	ar rc $(OUT) *.o
+	$(CC) -O2 -m64 -D_SQ64 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
+	$(AR) rc $(OUT) *.o
 	rm *.o
 
 sq64d:
-	gcc -O0 -g3 -m64 -D_SQ64 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
-	ar rc $(OUT) *.o
+	$(CC) -O0 -g3 -m64 -D_SQ64 -fno-exceptions -fno-rtti -Wall -fno-strict-aliasing -c $(SRCS) $(INCZ) $(DEFS)
+	$(AR) rc $(OUT) *.o
 
 .PHONY: clean mrproper
 


### PR DESCRIPTION
- Use CXX instead of CC and CXXFLAGS instead of CFLAGS for C++.
- Remove LD, because it is set to the same value as CXX.
- Don't overwrite CXX and CXXFLAGS if they are set as environment
  variables.
- Replace calls to:
  - g++ with $(CXX)
  - gcc with $(CC)
  - ar with $(AR)

See <https://www.gnu.org/software/make/manual/html_node/Implicit-Variables.html>.

----

Hardcoding tools can cause issues with cross-compiling and make it impossible to use a different compiler. Overwriting CXXFLAGS prevents me from adding additional compiler-flags (like `-march=native`).